### PR TITLE
Do not prompt for password when file is readable

### DIFF
--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -40,6 +40,16 @@ function! suda#read(expr, ...) abort range
         \ 'range': '',
         \}, a:0 ? a:1 : {}
         \)
+
+  if filereadable(path)
+    return substitute(execute(printf(
+          \ '%sread %s %s',
+          \ options.range,
+          \ options.cmdarg,
+          \ path,
+          \)), '^\r\?\n', '', '')
+  endif
+
   let tempfile = tempname()
   try
     let redirect = &shellredir =~# '%s'


### PR DESCRIPTION
Most files owned by root are readable.