### PR TITLE
Disable undo until after reading file in BufReadCmd

### DIFF
--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -117,6 +117,8 @@ endfunction
 
 function! suda#BufReadCmd() abort
   call s:doautocmd('BufReadPre')
+  let ul = &undolevels
+  set undolevels=-1
   try
     let echo_message = suda#read('<afile>', {
           \ 'range': '1',
@@ -127,6 +129,7 @@ function! suda#BufReadCmd() abort
     filetype detect
     redraw | echo echo_message
   finally
+    let &undolevels = ul
     call s:doautocmd('BufReadPost')
   endtry
 endfunction


### PR DESCRIPTION
Makes it so you can't undo until the buffer is blank.