### PR TITLE
enable multiple protocol prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This plugin is strongly inspired by [sudo.vim][] but the interfaces was aggressi
 Usage
 -------------------------------------------------------------------------------
 
-Use `suda://` prefix in `read`, `edit`, `write`, or `saveas` commands like.
+Use `suda://` prefix in `read`, `edit`, `write`, or `saveas` commands.
 
 ```vim
 " Open a current file with sudo
@@ -45,3 +45,9 @@ Use `suda://` prefix in `read`, `edit`, `write`, or `saveas` commands like.
 ```
 
 You can change the protocol prefix with `g:suda#prefix`.
+
+```vim
+let g:suda#prefix = 'suda://'
+" multiple protocols can be defined too
+let g:suda#prefix = ['suda://', 'sudo://', '_://']
+```

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -2,7 +2,12 @@ function! suda#init(...) abort
   let prefixes = s:totable(a:0 ? a:1 : g:suda#prefix)
   let pat = ''
   for prefix in prefixes
-    let pat .= printf(',%s*', prefix)
+    if match(prefix, '\/') == -1
+      let prefix .= printf('*,%s*/*', prefix)
+    else
+      let prefix .= '*'
+    endif
+    let pat .= printf(',%s', prefix)
   endfor
   let pat = pat[1:]
   augroup suda_internal

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -213,7 +213,7 @@ endfunction
 function! s:prefix_searchpattern() abort
   return printf(
         \ '^\%%(%s\)',
-        \ join(map(g:suda#prefix, { -> s:escape_patterns(v:val) }), '\|')
+        \ join(map(s:totable(g:suda#prefix), { -> s:escape_patterns(v:val) }), '\|')
         \)
 endfunction
 

--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -35,7 +35,7 @@ USAGE						*suda-usage*
 Add "suda://" prefix (see |g:suda#prefix|) to the filename and use Vim's
 builtin |read|, |edit|, |write|, |saveas| commands.
 
-For example
+For example:
 >
 	" Open a current file with sudo
 	:e suda://%
@@ -109,20 +109,26 @@ g:suda_startup
 
 						*g:suda#prefix*
 g:suda#prefix
-	Prefix string used as protocol.
+	Prefix string(s) used as protocol. Can be a string or a list.
 	Default: "suda://"
 
 
 =============================================================================
 QUESTIONS					*suda-questions*
 
-Q. How to use "sudo:" instead of "suda://" like "sudo.vim".
+Q. How to use "sudo:" instead of "suda://" like "sudo.vim"?
 A. Use |g:suda#prefix|| like below.
 >
 	let g:suda#prefix = 'sudo:'
 	call suda#init('sudo:*,sudo:*/*')
 <
-Q. How to use SudoRead/SudoWrite command like "sudo.vim".
+Q. How to use "sudo:" alongside "suda://"?
+A. Use a list in |g:suda#prefix|| like below.
+>
+	let g:suda#prefix = ['suda://', 'sudo:']
+	call suda#init('suda://*,sudo:*,sudo:*/*')
+<
+Q. How to use SudoRead/SudoWrite command like "sudo.vim"?
 A. Write the following scripts in your |vimrc|.
 >
 	command! -nargs=1 SudoRead  edit  suda://<args>

--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -120,13 +120,11 @@ Q. How to use "sudo:" instead of "suda://" like "sudo.vim"?
 A. Use |g:suda#prefix|| like below.
 >
 	let g:suda#prefix = 'sudo:'
-	call suda#init('sudo:*,sudo:*/*')
 <
 Q. How to use "sudo:" alongside "suda://"?
 A. Use a list in |g:suda#prefix|| like below.
 >
 	let g:suda#prefix = ['suda://', 'sudo:']
-	call suda#init('suda://*,sudo:*,sudo:*/*')
 <
 Q. How to use SudoRead/SudoWrite command like "sudo.vim"?
 A. Write the following scripts in your |vimrc|.


### PR DESCRIPTION
The new added FAQ says all.
>Q. How to use "sudo:" alongside "suda://"?
>A. Use a list in `g:suda#prefix` like below.
>```vim
>    let g:suda#prefix = ['suda://', 'sudo:']
>    call suda#init('suda://*,sudo:*,sudo:*/*')
>```
I have an `alias _='sudo '` in my shell. This current PR lets me use a similar `_://` sudo prefix while still keeping `suda://` or `sudo://` as sort of a standard default.

a list or prefixes, or a single prefix string, both are valid values for `g:suda#prefix` in this commit, so no change is required from the end-user perspective.