### PR TITLE
Add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+doc/tags
+*.swp


### PR DESCRIPTION
The tags file is created when running :PlugInstall and makes the
repository dirty. Ignoring *.swp files is always a good idea.

This is very common for vim plugins, see also:

- https://github.com/mhinz/vim-grepper/blob/master/.gitignore
- https://github.com/vim-airline/vim-airline/blob/master/.gitignore
- https://github.com/tpope/vim-fugitive/blob/master/.gitignore