### PR TITLE
Fix the prefix to suda:// and add SudaRead/SudaWrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,40 +16,27 @@ This plugin is strongly inspired by [sudo.vim][] but the interfaces was aggressi
 
 ## Usage
 
-Use `suda://` prefix in `read`, `edit`, `write`, or `saveas` commands.
+Use `SudaRead` to open unreadable files like:
 
-```vim
-" Open a current file with sudo
-:e suda://%
+```
+" Re-open a current file with sudo
+:SudaRead
 
-" Save a current file with sudo
-:w suda://%
+" Open /etc/sudoers with sudo
+:SudaRead /etc/sudoers
+```
 
-" Edit /etc/sudoers
-:e suda:///etc/sudoers
+Or `SudaWrite` to write unwritable files like:
 
-" Read /etc/sudoers (insert content under the cursor)
-:r suda:///etc/sudoers
-
-" Read /etc/sudoers at the end
-:$r suda:///etc/sudoers
+```
+" Forcedly save a current file with sudo
+:SudaWrite
 
 " Write contents to /etc/profile
-:w suda:///etc/profile
-
-" Save contents to /etc/profile
-:saveas suda:///etc/profile
+:SudaWrite /etc/profile
 ```
 
-You can change the protocol prefix with `g:suda#prefix`.
-
-```vim
-let g:suda#prefix = 'suda://'
-" multiple protocols can be defined too
-let g:suda#prefix = ['suda://', 'sudo://', '_://']
-```
-
-And you can change the prompt string with `g:suda#prompt`.
+You can change the prompt string with `g:suda#prompt`.
 
 ```vim
 " 'Password' in french

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -1,29 +1,3 @@
-function! suda#init(...) abort
-  let prefixes = s:totable(a:0 ? a:1 : g:suda#prefix)
-  let pat = ''
-  for prefix in prefixes
-    if match(prefix, '\/') is# -1
-      let prefix .= printf('*,%s*/*', prefix)
-    else
-      let prefix .= '*'
-    endif
-    let pat .= printf(',%s', prefix)
-  endfor
-  let pat = pat[1:]
-  augroup suda_internal
-    autocmd! *
-    execute printf('autocmd BufReadCmd %s call suda#BufReadCmd()', pat)
-    execute printf('autocmd FileReadCmd %s call suda#FileReadCmd()', pat)
-    execute printf('autocmd BufWriteCmd %s call suda#BufWriteCmd()', pat)
-    execute printf('autocmd FileWriteCmd %s call suda#FileWriteCmd()', pat)
-    " Pseudo autocmd to suppress 'No such autocmd' message
-    execute printf('autocmd BufReadPre,BufReadPost %s :', pat)
-    execute printf('autocmd FileReadPre,FileReadPost %s :', pat)
-    execute printf('autocmd BufWritePre,BufWritePost %s :', pat)
-    execute printf('autocmd FileWritePre,FileWritePost %s :', pat)
-  augroup END
-endfunction
-
 function! suda#system(cmd, ...) abort
   let cmd = has('win32')
         \ ? printf('sudo %s', a:cmd)
@@ -46,7 +20,8 @@ function! suda#system(cmd, ...) abort
 endfunction
 
 function! suda#read(expr, ...) abort range
-  let path = s:expand_expression(a:expr)
+  let path = s:strip_prefix(expand(a:expr))
+  let path = fnamemodify(path, ':p')
   let options = extend({
         \ 'cmdarg': v:cmdarg,
         \ 'range': '',
@@ -96,7 +71,8 @@ function! suda#read(expr, ...) abort range
 endfunction
 
 function! suda#write(expr, ...) abort range
-  let path = s:expand_expression(a:expr)
+  let path = s:strip_prefix(expand(a:expr))
+  let path = fnamemodify(path, ':p')
   let options = extend({
         \ 'cmdarg': v:cmdarg,
         \ 'cmdbang': v:cmdbang,
@@ -146,7 +122,7 @@ function! suda#write(expr, ...) abort range
 endfunction
 
 function! suda#BufReadCmd() abort
-  call s:doautocmd('BufReadPre')
+  doautocmd <nomodeline> BufReadPre
   let ul = &undolevels
   set undolevels=-1
   try
@@ -161,12 +137,12 @@ function! suda#BufReadCmd() abort
     redraw | echo echo_message
   finally
     let &undolevels = ul
-    call s:doautocmd('BufReadPost')
+    doautocmd <nomodeline> BufReadPost
   endtry
 endfunction
 
 function! suda#FileReadCmd() abort
-  call s:doautocmd('FileReadPre')
+  doautocmd <nomodeline> FileReadPre
   try
     " XXX
     " A '[ mark indicates the {range} of the command.
@@ -177,36 +153,35 @@ function! suda#FileReadCmd() abort
           \ 'range': range,
           \})
   finally
-    call s:doautocmd('FileReadPost')
+    doautocmd <nomodeline> FileReadPost
   endtry
 endfunction
 
 function! suda#BufWriteCmd() abort
-  call s:doautocmd('BufWritePre')
+  doautocmd <nomodeline> BufWritePre
   try
     let echo_message = suda#write('<afile>', {
           \ 'range': '''[,'']',
           \})
     let lhs = expand('%')
     let rhs = expand('<afile>')
-    let pat = s:prefix_searchpattern()
-    if lhs ==# rhs || substitute(rhs, pat, '', '') ==# lhs
+    if lhs ==# rhs || substitute(rhs, '^suda://', '', '') ==# lhs
       setlocal nomodified
     endif
     redraw | echo echo_message
   finally
-    call s:doautocmd('BufWritePost')
+    doautocmd <nomodeline> BufWritePost
   endtry
 endfunction
 
 function! suda#FileWriteCmd() abort
-  call s:doautocmd('FileWritePre')
+  doautocmd <nomodeline> FileWritePre
   try
     redraw | echo suda#write('<afile>', {
           \ 'range': '''[,'']',
           \})
   finally
-    call s:doautocmd('FileWritePost')
+    doautocmd <nomodeline> FileWritePost
   endtry
 endfunction
 
@@ -239,10 +214,8 @@ function! suda#BufEnter() abort
     endwhile
   endif
   let bufnr = str2nr(expand('<abuf>'))
-  let prefix = get(s:totable(g:suda#prefix), 0, 'suda://')
   execute printf(
-        \ 'keepalt keepjumps edit %s%s',
-        \ prefix,
+        \ 'keepalt keepjumps edit suda://%s',
         \ fnamemodify(bufname, ':p'),
         \)
   execute printf('silent! %dbwipeout', bufnr)
@@ -252,33 +225,18 @@ function! s:escape_patterns(expr) abort
   return escape(a:expr, '^$~.*[]\')
 endfunction
 
-function! s:expand_expression(expr) abort
-  return fnamemodify(
-        \ substitute(expand(a:expr), s:prefix_searchpattern(), '', ''),
-        \ ':p'
-        \)
+function! s:strip_prefix(expr) abort
+  return substitute(a:expr, '^suda://', '', '')
 endfunction
 
-function! s:prefix_searchpattern() abort
-  return printf(
-        \ '^\%%(%s\)',
-        \ join(map(s:totable(g:suda#prefix), { -> s:escape_patterns(v:val) }), '\|')
-        \)
-endfunction
-
-function! s:totable(expr) abort
-  return type(a:expr) == v:t_list ? a:expr : [a:expr]
-endfunction
-
-function! s:doautocmd(name) abort
-  execute printf(
-        \ 'doautocmd %s %s',
-        \ a:name,
-        \ fnameescape(expand('<afile>'))
-        \)
-endfunction
-
+" Pseudo autocmd to suppress 'No such autocmd' message
+augroup suda_internal
+  autocmd!
+  autocmd BufReadPre,BufReadPost     suda://* :
+  autocmd FileReadPre,FileReadPost   suda://* :
+  autocmd BufWritePre,BufWritePost   suda://* :
+  autocmd FileWritePre,FileWritePost suda://* :
+augroup END
 
 " Configure
-let g:suda#prefix = get(g:, 'suda#prefix', 'suda://')
 let g:suda#prompt = get(g:, 'suda#prompt', 'Password: ')

--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -1,6 +1,5 @@
 *suda.txt*			Use sudo to read/write files in Vim/Neovim
 
-Version: 0.1.0
 Author:  Alisue <lambdalisue@hashnote.net>
 License: MIT license
 
@@ -9,10 +8,12 @@ CONTENTS					*suda-contents*
 
 Introduction			|suda-introduction|
 Usage				|suda-usage|
+  Smart-edit			|suda-usage-smart-edit|
+  Windows			|suda-usage-windows|
 Interface			|suda-interface|
-  Functions			|suda-functions|
-  Variables			|suda-variables|
-Questions			||suda-questions|
+  Command			|suda-interface-command|
+  Function			|suda-interface-function|
+  Variable			|suda-interface-variable|
 
 
 =============================================================================
@@ -40,10 +41,23 @@ Make sure that the following shows 1.
 =============================================================================
 USAGE						*suda-usage*
 
-Add "suda://" prefix (see |g:suda#prefix|) to the filename and use Vim's
-builtin |read|, |edit|, |write|, |saveas| commands.
+Use |:SudaRead| to open unreadable files like:
+>
+	" Re-open a current file with sudo
+	:SudaRead
 
-For example:
+	" Open /etc/sudoers with sudo
+	:SudaRead /etc/sudoers
+<
+Or use |:SudaWrite| to write unwritable files like:
+>
+	" Forcedly save a current file with sudo
+	:SudaWrite
+
+	" Write contents to /etc/profile with sudo
+	:SudaWrite /etc/profile
+<
+Or directly use "suda://" prefix on |read|, |edit|, |write|, or |saveas| like:
 >
 	" Open a current file with sudo
 	:e suda://%
@@ -66,22 +80,57 @@ For example:
 	" Save contents to /etc/profile
 	:saveas suda:///etc/profile
 <
-You can change the protocol prefix with |g:suda#prefix|.
+You can change the prompt string by |g:suda#prompt| like:
+>
+	" 'Password' in french
+	let g:suda#prompt = 'Mot de passe: '
+<
+-----------------------------------------------------------------------------
+SMART-EDIT					*suda-usage-smart-edit*
 
+When |g:suda_smart_edit| is true, suda automatically switch a buffer name when
+the target file is not readable or writable.
+
+In short,
+>
+	$ vim /etc/hosts
+<
+or
+>
+	:e /etc/shadow
+<
+Will open "suda:///etc/hosts" or "suda:///etc/shadow" instead of "/etc/hosts"
+or "/etc/shadow" because that files are not writable or not readable.
+
+-----------------------------------------------------------------------------
+WINDOWS						*suda-usage-windows*
+
+Install https://github.com/mattn/sudo to enable this plugin in Windows.
+Make sure that the following shows 1.
+>
+	: echo executable('sudo')
+<
 
 =============================================================================
 INTERFACE					*suda-interface*
 
 -----------------------------------------------------------------------------
-FUNCTIONS					*suda-functions*
+COMMAND						*suda-interface-command*
 
-						*suda#init()*
-suda#init([{pat}])
-	Initialize suda. It registers required autocmds so that user can use
-	|read|, |edit|, |write|, and |saveas| commands.
-	The {pat} is used for |autocmd|.
+						*:SudaRead*
+:SudaRead [{path}]
+	Edit the {path} or re-open the current buffer with sudo.
+	It is equivalent to ":e suda://{path}"
 
+						*:SudaWrite*
+:SudaWrite [{path}]
+	Save content of the current buffer or save it to the {path} with sudo.
+	It is equivalent to ":w suda://{path}"
 
+-----------------------------------------------------------------------------
+FUNCTION					*suda-interface-function*
+
+						*suda#system()*
 suda#system({cmd} [, {input}])
 	Like |system()| but execute {cmd} with "sudo".
 
@@ -109,55 +158,20 @@ suda#write({expr} [, {options}])
 	buffer internally.
 
 -----------------------------------------------------------------------------
-VARIABLES					*suda-variables*
+VARIABLE					*suda-interface-variable*
 
-						*g:suda_startup*
-g:suda_startup
-	If set, call |suda#init()| automatically on suda's buffers, according
-	to the prefix.
-	Default: 1
-
-						*g:suda#prefix*
-g:suda#prefix
-	Prefix string(s) used as protocol. Can be a string or a list.
-	Default: "suda://"
-
-						*g:suda#prompt*
-g:suda#prompt
+*g:suda#prompt*
 	A prompt string used to ask password.
 	Default: "Password: "
 
-						*g:suda_smart_edit*
-g:suda_smart_edit
+*g:suda_smart_edit*
 	If set, an |autocmd| is created that performs a heuristic check on
-	every buffer and decides whether to replace it with a suda buffer i.e
-	`suda://%` - depending on your |g:suda#prefix|, naturally. The check
-	is done only once for every buffer and it is designed to be optimized
-	as possible so you shouldn't feel any slowdown when openning buffers.
+	every buffer and decides whether to replace it with a suda buffer.
+	The check is done only once for every buffer and it is designed to be
+	optimized as possible so you shouldn't feel any slowdown when openning
+	buffers.
 	Default: 0
 
-=============================================================================
-QUESTIONS					*suda-questions*
 
-Q. How to use "sudo:" instead of "suda://" like "sudo.vim"?
-A. Use |g:suda#prefix|| like below.
->
-	let g:suda#prefix = 'sudo:'
-<
-Q. How to use "sudo:" alongside "suda://"?
-A. Use a list in |g:suda#prefix|| like below.
->
-	let g:suda#prefix = ['suda://', 'sudo:']
-<
-Q. How to use SudoRead/SudoWrite command like "sudo.vim"?
-A. Write the following scripts in your |vimrc|.
->
-	command! -nargs=1 SudoRead  edit  suda://<args>
-	command! -nargs=1 SudoWrite write suda://<args>
-
-	" Or with 'sudo:'
-	command! -nargs=1 SudoRead  edit  sudo:<args>
-	command! -nargs=1 SudoWrite write sudo:<args>
-<
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/plugin/suda.vim
+++ b/plugin/suda.vim
@@ -3,13 +3,17 @@ if exists('g:loaded_suda')
 endif
 let g:loaded_suda = 1
 
-if get(g:, 'suda_startup', 1)
-  call suda#init()
-endif
-
 if get(g:, 'suda_smart_edit')
   augroup suda_smart_edit
     autocmd!
     autocmd BufEnter * nested call suda#BufEnter()
   augroup end
 endif
+
+augroup suda_plugin
+  autocmd!
+  autocmd BufReadCmd   suda://* call suda#BufReadCmd()
+  autocmd FileReadCmd  suda://* call suda#FileReadCmd()
+  autocmd BufWriteCmd  suda://* call suda#BufWriteCmd()
+  autocmd FileWriteCmd suda://* call suda#FileWriteCmd()
+augroup END

--- a/plugin/suda.vim
+++ b/plugin/suda.vim
@@ -17,3 +17,15 @@ augroup suda_plugin
   autocmd BufWriteCmd  suda://* call suda#BufWriteCmd()
   autocmd FileWriteCmd suda://* call suda#FileWriteCmd()
 augroup END
+
+function! s:read(args) abort
+  let args = empty(a:args) ? expand('%:p') : a:args
+  execute printf('edit suda://%s', args)
+endfunction
+command! -nargs=? -complete=file SudaRead  call s:read(<q-args>)
+
+function! s:write(args) abort
+  let args = empty(a:args) ? expand('%:p') : a:args
+  execute printf('write suda://%s', args)
+endfunction
+command! -nargs=? -complete=file SudaWrite call s:write(<q-args>)


### PR DESCRIPTION
I'm tired to care flexible prefixes.

- :boom:  Fix the prefix to suda:// and remove `g:suda#prefix`
- :sparkles:  Add `SudaRead` and `SudaWrite` commands