### PR TITLE
Make it possible to try authentication methods that require no text input before prompting for a password.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ You can change the prompt string with `g:suda#prompt`.
 let g:suda#prompt = 'Mot de passe: '
 ```
 
+If you have configured `sudo` to use authentication methods that require no text input (like fingerprint or YubiKey) before password authentication, add `let g:suda#try_no_text_input_auth = 1` to you vim configuration. You can also change the extra prompt message in this case with `g:suda#try_no_text_input_auth_prompt`. These two options are not available for MS Windows.
+
 ### Smart edit
 
 When `let g:suda_smart_edit = 1` is written in your vimrc, suda automatically switch a buffer name when the target file is not readable or writable.

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -1,9 +1,20 @@
 function! suda#system(cmd, ...) abort
-  let cmd = has('win32')
-        \ ? printf('sudo %s', a:cmd)
+  if has('win32')
+    let cmd = printf('sudo %s', a:cmd)
+    if &verbose
+      echomsg '[suda]' cmd
+    endif
+    let result = a:0 ? system(cmd, a:1) : system(cmd)
+    return result
+  endif
+  let cmd = g:suda#try_no_text_input_auth
+        \ ? printf('sudo -p '''' -S %s', a:cmd)
         \ : printf('sudo -p '''' -n %s', a:cmd)
   if &verbose
     echomsg '[suda]' cmd
+  endif
+  if g:suda#try_no_text_input_auth
+    redraw | echo g:suda#try_no_text_input_auth_prompt
   endif
   let result = a:0 ? system(cmd, a:1) : system(cmd)
   if v:shell_error == 0
@@ -263,3 +274,12 @@ augroup END
 
 " Configure
 let g:suda#prompt = get(g:, 'suda#prompt', 'Password: ')
+
+if !has('win32')
+  let g:suda#try_no_text_input_auth = get(g:, 'suda#try_no_text_input_auth')
+  let g:suda#try_no_text_input_auth_prompt = get(
+        \ g:,
+        \ 'suda#try_no_text_input_auth_prompt',
+        \ 'Try authentication methods that require no text input.',
+        \)
+endif

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -264,7 +264,7 @@ function! s:escape_patterns(expr) abort
 endfunction
 
 function! s:strip_prefix(expr) abort
-  return substitute(a:expr, '^suda://', '', '')
+  return substitute(a:expr, '\v^(suda://)+', '', '')
 endfunction
 
 function! s:echomsg_exception() abort

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -2,7 +2,7 @@ function! suda#system(cmd, ...) abort
   if has('win32')
     let cmd = printf('sudo %s', a:cmd)
     if &verbose
-      echomsg '[suda]' cmd
+      unsilent echomsg '[suda]' cmd
     endif
     let result = a:0 ? system(cmd, a:1) : system(cmd)
     return result
@@ -11,10 +11,10 @@ function! suda#system(cmd, ...) abort
         \ ? printf('sudo -p '''' -S %s', a:cmd)
         \ : printf('sudo -p '''' -n %s', a:cmd)
   if &verbose
-    echomsg '[suda]' cmd
+    unsilent echomsg '[suda]' cmd
   endif
   if g:suda#try_no_text_input_auth
-    redraw | echo g:suda#try_no_text_input_auth_prompt
+    redraw | unsilent echo g:suda#try_no_text_input_auth_prompt
   endif
   let result = a:0 ? system(cmd, a:1) : system(cmd)
   if v:shell_error == 0
@@ -152,7 +152,7 @@ function! suda#BufReadCmd() abort
     setlocal nobackup noswapfile noundofile
     setlocal nomodified
     filetype detect
-    redraw | echo echo_message
+    redraw | unsilent echo echo_message
   catch
     call s:echomsg_exception()
   finally
@@ -169,7 +169,7 @@ function! suda#FileReadCmd() abort
     " However, the mark becomes 1 even user execute ':0read'.
     " So check the last command to find if the {range} was 0 or not.
     let range = histget('cmd', -1) =~# '^0r\%[ead]\>' ? '0' : '''['
-    redraw | echo suda#read('<afile>', {
+    redraw | unsilent echo suda#read('<afile>', {
           \ 'range': range,
           \})
   catch
@@ -190,7 +190,7 @@ function! suda#BufWriteCmd() abort
     if lhs ==# rhs || substitute(rhs, '^suda://', '', '') ==# lhs
       setlocal nomodified
     endif
-    redraw | echo echo_message
+    redraw | unsilent echo echo_message
   catch
     call s:echomsg_exception()
   finally
@@ -201,7 +201,7 @@ endfunction
 function! suda#FileWriteCmd() abort
   doautocmd <nomodeline> FileWritePre
   try
-    redraw | echo suda#write('<afile>', {
+    redraw | unsilent echo suda#write('<afile>', {
           \ 'range': '''[,'']',
           \})
   catch
@@ -259,7 +259,7 @@ function! s:echomsg_exception() abort
   redraw
   echohl ErrorMsg
   for line in split(v:exception, '\n')
-    echomsg printf('[suda] %s', line)
+    unsilent echomsg printf('[suda] %s', line)
   endfor
 endfunction
 

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -273,6 +273,7 @@ function! s:echomsg_exception() abort
   for line in split(v:exception, '\n')
     unsilent echomsg printf('[suda] %s', line)
   endfor
+  echohl None
 endfunction
 
 " Pseudo autocmd to suppress 'No such autocmd' message

--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -164,11 +164,21 @@ VARIABLE					*suda-interface-variable*
 	A prompt string used to ask password.
 	Default: "Password: "
 
+*g:suda#try_no_text_input_auth*
+	Try authentication methods that require no text input before prompting
+	for a password. Not available for MS Windows.
+	Default: 0
+
+*g:suda#try_no_text_input_auth_prompt*
+	A prompt string shown when trying authentication methods that require
+	no text input.
+	Default: "Try authentication methods that require no text input."
+
 *g:suda_smart_edit*
 	If set, an |autocmd| is created that performs a heuristic check on
 	every buffer and decides whether to replace it with a suda buffer.
 	The check is done only once for every buffer and it is designed to be
-	optimized as possible so you shouldn't feel any slowdown when openning
+	optimized as possible so you shouldn't feel any slowdown when opening
 	buffers.
 	Default: 0
 


### PR DESCRIPTION
Resolves: #36

This PR adds two variables `g:suda#try_no_text_input_auth` and `g:suda#try_no_text_input_auth_prompt` that make it possible to try authentication methods that require no text input before prompting for a password. Other included changes are listed below:

- `unsilent` is prepended to `:echo` and `:echomsg` calls because of [this reason](https://github.com/neovim/neovim/wiki/FAQ#calling-inputlist-echomsg-etc-in-filetype-plugins-and-autocmd-does-not-work). Without `unsilent` messages aren't shown when this plugin handles file reading.
- `dd` is used instead of `cat` with shell redirection to read a file in Unix-like operating systems and write it to the temporary files. This change is introduced because even if called with `-p ''`, `sudo` may use PAM modules that write messages to stdout (like `pam_fprintd.so` in Linux), which, when `cat` with shell redirection is used, also get redirected into the temporary file. `dd` can write to the temporary file directly, so it can solve the aforementioned problem. I think it is safe to assume temporary files created by calling `writefile()` on `tempname()` is writable when using `sudo`.
- `:echohl None` is added to the end of `s:echomsg_exception()`.
- `s:strip_prefix()` removes all `suda://` prefixes instead of just one, so both `:write` and `:SudaWrite` work for buffers opened using `:SudaRead`.