### PR TITLE
Add gsudo on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Will open `suda:///etc/hosts` or `suda:///etc/shadow` instead of `/etc/hosts` or
 
 ### Windows
 
-Install [mattn/sudo](https://github.com/mattn/sudo) to enable this plugin in Windows.
+Install [gerardog/gsudo](https://github.com/gerardog/gsudo) to enable this plugin in Windows.
 Make sure that the following shows `1`.
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Will open `suda:///etc/hosts` or `suda:///etc/shadow` instead of `/etc/hosts` or
 
 ### Windows
 
-Install [gerardog/gsudo](https://github.com/gerardog/gsudo) to enable this plugin in Windows.
+Install [mattn/sudo](https://github.com/mattn/sudo) or [gerardog/gsudo](https://github.com/gerardog/gsudo) to enable this plugin in Windows.
 Make sure that the following shows `1`.
 
 ```vim


### PR DESCRIPTION
It's better to point to [gsudo](https://github.com/gerardog/gsudo) because it is more popular and maintained. No changes in the code; it still works (assuming `sudo` is aliased to `gsudo`, which the installers do).