### PR TITLE
suda_nopass option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ Make sure that the following shows `1`.
 
 ### Use sudo without a password
 
-When `let g:suda_nopass = 1` is written in your vimrc, suda won't ask you for a password. Use at your own risk.
+When `let g:suda#nopass = 1` is written in your vimrc, suda won't ask you for a password. Use at your own risk.

--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ Make sure that the following shows `1`.
 ```vim
 : echo executable('sudo')
 ```
+
+### Use sudo without a password
+
+When `let g:suda_nopass = 1` is written in your vimrc, suda won't ask you for a password. Use at your own risk.

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -1,5 +1,5 @@
 function! suda#system(cmd, ...) abort
-  let cmd = has('win32')
+  let cmd = has('win32') || get(g:, 'suda_nopass')
         \ ? printf('sudo %s', a:cmd)
         \ : printf('sudo -p '''' -n %s', a:cmd)
   if &verbose

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -1,5 +1,5 @@
 function! suda#system(cmd, ...) abort
-  let cmd = has('win32') || get(g:, 'suda_nopass')
+  let cmd = has('win32') || get(g:, 'suda#nopass')
         \ ? printf('sudo %s', a:cmd)
         \ : printf('sudo -p '''' -n %s', a:cmd)
   if &verbose

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -1,5 +1,5 @@
 function! suda#system(cmd, ...) abort
-  let cmd = has('win32') || get(g:, 'suda#nopass')
+  let cmd = has('win32') || g:suda#nopass
         \ ? printf('sudo %s', a:cmd)
         \ : printf('sudo -p '''' -n %s', a:cmd)
   if &verbose
@@ -264,3 +264,4 @@ augroup END
 
 " Configure
 let g:suda#prompt = get(g:, 'suda#prompt', 'Password: ')
+let g:suda#nopass = get(g:, 'suda#nopass', 0)

--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -179,6 +179,11 @@ VARIABLE					*suda-interface-variable*
 	optimized as possible so you shouldn't feel any slowdown when openning
 	buffers.
 	Default: 0
+g:suda#nopass
+        If set, suda will not prompt you for a password before saving a file.
+        It is suppossed to support a setup with passwordless sudo or doas.
+        Use with care.
+        Default: 0
 
 
 =============================================================================

--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -110,6 +110,14 @@ Make sure that the following shows 1.
 >
 	: echo executable('sudo')
 <
+-----------------------------------------------------------------------------
+NOPASS						*suda-usage-nopass*
+
+
+When `let g:suda#nopass = 1` is written in your vimrc, suda won't ask you for a password.
+Use at your own risk.
+
+
 
 =============================================================================
 INTERFACE					*suda-interface*


### PR DESCRIPTION
I introduced little change.

If following option is set:

`let g:suda_nopass = 1`

Suda won't ask for a password before saving.

It is very useful if you don't require password to sudo on your system, and also will work with `doas` (provided you don't require a password and doas acts in place of `sudo` - as a symlink or a shim).