### PR TITLE
fix: use full path when setting nomodified

### DIFF
--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -174,7 +174,7 @@ function! suda#BufWriteCmd() abort
     let echo_message = suda#write('<afile>', {
           \ 'range': '''[,'']',
           \})
-    let lhs = expand('%')
+    let lhs = expand('%:p')
     let rhs = expand('<afile>')
     if lhs ==# rhs || substitute(rhs, '^suda://', '', '') ==# lhs
       setlocal nomodified


### PR DESCRIPTION
For me, `nomodified` was never setting because this if condition was failing due to `lhs` having file name and `rhs` having file path