### PR TITLE
call checktime after write to warn about changed files

### DIFF
--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -126,6 +126,8 @@ function! suda#write(expr, ...) abort range
   finally
     silent call delete(tempfile)
   endtry
+  " Warn that this file has changed
+  checktime
 endfunction
 
 function! suda#BufReadCmd() abort


### PR DESCRIPTION
This was first suggested in #43 and was forgotten after. This simply adds the call to the end of suda#Write().
