### PR TITLE
only use arguments on suda#executable if it's equal to "sudo"

### DIFF
--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -1,7 +1,13 @@
+function! s:get_command(opts)
+    return g:suda#executable ==# "sudo" && len(a:opts) > 0
+          \ ? printf('%s %s', g:suda#executable, a:opts)
+          \ : g:suda#executable
+endfunction
+
 function! suda#system(cmd, ...) abort
   let cmd = has('win32') || g:suda#nopass
-        \ ? printf('%s %s', g:suda#executable, a:cmd)
-        \ : printf('%s -p '''' -n %s', g:suda#executable, a:cmd)
+        \ ? printf('%s %s', s:get_command(''), a:cmd)
+        \ : printf('%s %s', s:get_command('-p '''' -n'), a:cmd)
   if &verbose
     echomsg '[suda]' cmd
   endif
@@ -9,23 +15,29 @@ function! suda#system(cmd, ...) abort
   if v:shell_error == 0
     return result
   endif
+  let ask_pass = 1
   " Let's try running a command non-interactively. If it works, we have a sudo
   " timestamp that has not timed out yet. In this case there is no need to ask
   " for a password.
   " This only works if the timestamp_type is set to 'global' in the sudo
   " configuation file. It does not work with 'ppid', 'kernel' or 'tty'.
-  let cmd = printf('%s -n true', g:suda#executable)
-  let result = system(cmd)
-  if v:shell_error == 0
-    let cmd = printf('%s %s', g:suda#executable, a:cmd)
-  else
+  " Note: for non-sudo commands, don't do this, instead *always* ask for the password
+  if g:suda#executable ==# "sudo"
+    let cmd = printf('%s -n true', g:suda#executable)
+    let result = system(cmd)
+    if v:shell_error == 0
+      let cmd = printf('%s %s', g:suda#executable, a:cmd)
+      let ask_pass = 0
+    endif
+  endif
+  if ask_pass == 1
     try
       call inputsave()
       redraw | let password = inputsecret(g:suda#prompt)
     finally
       call inputrestore()
     endtry
-    let cmd = printf('%s -p '''' -S %s', g:suda#executable, a:cmd)
+    let cmd = printf('%s %s', s:get_command('-p '''' -S'), a:cmd)
   endif
   return system(cmd, password . "\n" . (a:0 ? a:1 : ''))
 endfunction


### PR DESCRIPTION
This ensures that the sudo options work correctly, and creates *rudimentary* support for other commands (such as `doas`, see #40)

This isn't perfect, but likely the best we can do (see [my comment](https://github.com/lambdalisue/suda.vim/issues/40#issuecomment-1640903171)).

This change allows any command which accepts no password, or else a password from stdin to work. Any command set to `g:suda#executable` will be executed with no further arguments (so the user may need to provide any needed), and will be run, first with an empty stdin, then with the user's provided password as stdin. Further support would likely need to be added on a case-by-case basis and may quickly spiral out of control. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced command construction for improved reliability and security.
	- Introduced interactive password prompts for certain operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->