### PR TITLE
Do not ask for password if not needed.

### DIFF
--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -37,6 +37,17 @@ Make sure that the following shows 1.
 >
 	: echo executable('sudo')
 <
+*suda* will ask for a password each time sudo is used for reading or writing.
+However, you can set global timestamps in your sudoers configuration, if you
+have sudo version 1.8.21 or higher. This will enable *suda* to reuse an
+existing sudo authentication token. In this case, it will not ask for a
+password if not needed. To enable, configure sudo with this option:
+>
+        Defaults timestamp_type = global
+<
+The other types 'ppid', 'kernel' or 'tty' will not allow *suda* to use sudo
+credential caching. Please make sure this is in line with your security
+requirements.
 
 =============================================================================
 USAGE						*suda-usage*


### PR DESCRIPTION
In certain circumstances we do not need to ask for a password because we already have previously authenticated to sudo and can just reuse the credentials.

Since there is no way to check if a sudo timestamp has timed out we run a simple command and check the result.

Using an existing sudo timestamp from within nvim seems to work only if the timestamp_type is set to 'global' in the sudo configuration file.

The assesment of the risk of setting the security relevant setting timestamp_type to 'global' needs to be done by the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the method of command execution in the `suda` plugin to improve user experience by reducing unnecessary password prompts.
- **Documentation**
	- Enhanced `suda` functionality documentation to include support for global timestamps for sudo authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->