### PR TITLE
Fix duplicated help tag `suda`

### DIFF
--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -37,15 +37,15 @@ Make sure that the following shows 1.
 >
 	: echo executable('sudo')
 <
-*suda* will ask for a password each time sudo is used for reading or writing.
+|suda| will ask for a password each time sudo is used for reading or writing.
 However, you can set global timestamps in your sudoers configuration, if you
-have sudo version 1.8.21 or higher. This will enable *suda* to reuse an
+have sudo version 1.8.21 or higher. This will enable |suda| to reuse an
 existing sudo authentication token. In this case, it will not ask for a
 password if not needed. To enable, configure sudo with this option:
 >
         Defaults timestamp_type = global
 <
-The other types 'ppid', 'kernel' or 'tty' will not allow *suda* to use sudo
+The other types 'ppid', 'kernel' or 'tty' will not allow |suda| to use sudo
 credential caching. Please make sure this is in line with your security
 requirements.
 


### PR DESCRIPTION
This PR fixes the following error.
```
E154: Duplicate tag "suda"
```

📝 reproduce script
```vim
helptags /path/to/suda.vim
```

Fix: https://github.com/lambdalisue/suda.vim/issues/72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation to enhance clarity around the usage of `suda` in sudo authentication contexts, including a formatting change for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->