### PR TITLE
fix: rename suda#nopass to suda#noninteractive

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ Make sure that the following shows `1`.
 
 ### Use sudo without a password
 
-When `let g:suda#nopass = 1` is written in your vimrc, suda won't ask you for a password. Use at your own risk.
+When `let g:suda#noninteractive = 1` is written in your vimrc, suda won't ask you for a password. Use at your own risk.

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -18,7 +18,7 @@ endfunction
 " {input} (a:1) is a string to pass as stdin to the command
 " Returns a list of the command's output, split by NLs, with NULs replaced with NLs.
 function! suda#systemlist(cmd, ...) abort
-  let cmd = has('win32') || g:suda#nointeractive
+  let cmd = has('win32') || g:suda#noninteractive
         \ ? s:get_command([], a:cmd)
         \ : s:get_command(['-p', '', '-n'], a:cmd)
   if &verbose

--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -10,7 +10,7 @@ function! s:get_command(opts, cmd)
 endfunction
 
 function! suda#system(cmd, ...) abort
-  let cmd = has('win32') || g:suda#nopass
+  let cmd = has('win32') || g:suda#noninteractive
         \ ? s:get_command('', a:cmd)
         \ : s:get_command('-p '''' -n', a:cmd)
   if &verbose
@@ -293,6 +293,7 @@ augroup suda_internal
 augroup END
 
 " Configure
-let g:suda#nopass = get(g:, 'suda#nopass', 0)
+" Use suda#noninteractive if defined, else suda#nopass for backwards compatability, default to 0
+let g:suda#noninteractive = get(g:, 'suda#noninteractive', get(g:, 'suda#nopass', 0))
 let g:suda#prompt = get(g:, 'suda#prompt', 'Password: ')
 let g:suda#executable = get(g:, 'suda#executable', 'sudo')

--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -175,7 +175,7 @@ VARIABLE					*suda-interface-variable*
 	A executable of "sudo" command.
 	Default: "sudo"
 
-*g:suda#nopass*
+*g:suda#noninteractive*
 	If set, suda will not prompt you for a password before saving a file.
 	It is suppossed to support a setup with passwordless sudo or doas.
 	Use with care.


### PR DESCRIPTION
fixes #73. Maintains a fallback to suda#nopass for backwards compatability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced user control over password prompts in the Vim `suda` plugin. The setting `g:suda#noninteractive` now replaces `g:suda#nopass` and defaults to `0` if not explicitly defined.

- **Documentation**
	- Updated documentation to reflect changes in configuration settings and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->