### PR TITLE
fix: join the shell opts to a string in `suda#systemlist`

### DIFF
--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -3,15 +3,20 @@
 " {opts} should be *sudo-specific*, while {cmd} is passed to any suda#executable
 " Note: {cmd} can not have any sudo flags. Put these into {opts}, as '--' is passed before {cmd}
 " Similarly, {opts} should *not* contain '--'
+" Returns a string that is safe to pass to `system` on both vim and neovim
 function! s:get_command(opts, cmd)
   if g:suda#executable ==# 'sudo' 
-    return [g:suda#executable] + a:opts + ['--'] + a:cmd
+    let ret = [g:suda#executable] + a:opts + ['--'] + a:cmd
+  else
+    " TODO:
+    " Should we pass '--' before cmd when using a custom suda#executable?
+    " Should suda#executable be split? Should we allow suda#executable to be a list instead?
+    " This behavior is entirely undocumented
+    let ret =  [g:suda#executable] + a:cmd
   endif
-  " TODO:
-  " Should we pass '--' before cmd when using a custom suda#executable?
-  " Should suda#executable be split? Should we allow suda#executable to be a list instead?
-  " This behavior is entirely undocumented
-  return [g:suda#executable] + a:cmd
+
+  " TODO: Should we detect `has('neovim')` and return a list to avoid a shell?
+  return join(map(ret, { k, v -> shellescape(v) }), ' ')
 endfunction
 
 " {cmd} is a argv list for the process


### PR DESCRIPTION
This avoids an error on vim.
fixes #77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved command string construction in the Suda plugin to enhance compatibility and potential future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->