### PR TITLE
docs: add lazy.nvim smart edit installation hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ This plugin is strongly inspired by [sudo.vim][] but the interfaces was aggressi
 [sudo.vim]: https://github.com/vim-scripts/sudo.vim
 [neovim]: https://github.com/neovim/neovim
 
+## Installation
+
+### folke/lazy.nvim
+
+Smart Edit is recommended. Lazy.nvim requires this variable to be defined like this due to its lazy loading:
+
+``` init.lua
+  {
+    "lambdalisue/vim-suda",
+    init = function()
+      vim.g.suda_smart_edit = 1
+    end
+  },
+```
+
+### junegunn/vim-plug
+
+``` init.vim
+Plug 'lambdalisue/vim-suda'
+
+" recommended
+let g:suda_smart_edit = 1
+```
+
 ## Usage
 
 Use `SudaRead` to open unreadable files like:


### PR DESCRIPTION
Smart edit doesn't work as straight forward with lazy.nvim. I made it work and want to share the fix for the next poor sap. Wrote it so that smart edit is recommended, so that it becomes the "sensible default". It's the best feature of this plugin IMHO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new "Installation" section in the `README.md` with detailed instructions for two plugin managers: `folke/lazy.nvim` and `junegunn/vim-plug`.
	- Maintained existing usage instructions and features, including commands and smart editing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->