### PR TITLE
Use common prefix for all options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let g:suda#prompt = 'Mot de passe: '
 
 ### Smart edit
 
-When `let g:suda_smart_edit = 1` is written in your vimrc, suda automatically switch a buffer name when the target file is not readable or writable.
+When `let g:suda#smart_edit = 1` is written in your vimrc, suda automatically switch a buffer name when the target file is not readable or writable.
 
 In short,
 

--- a/doc/suda.txt
+++ b/doc/suda.txt
@@ -185,7 +185,7 @@ VARIABLE					*suda-interface-variable*
 	A prompt string used to ask password.
 	Default: "Password: "
 
-*g:suda_smart_edit*
+*g:suda#smart_edit*
 	If set, an |autocmd| is created that performs a heuristic check on
 	every buffer and decides whether to replace it with a suda buffer.
 	The check is done only once for every buffer and it is designed to be

--- a/plugin/suda.vim
+++ b/plugin/suda.vim
@@ -3,7 +3,7 @@ if exists('g:loaded_suda')
 endif
 let g:loaded_suda = 1
 
-if get(g:, 'suda_smart_edit')
+if get(g:, 'suda_smart_edit') or get(g:, 'suda#smart_edit')
   augroup suda_smart_edit
     autocmd!
     autocmd BufEnter * nested call suda#BufEnter()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the configuration variable for smart editing from `g:suda_smart_edit` to `g:suda#smart_edit` for improved clarity.
	- Enhanced logic for the smart edit feature to accommodate the new variable.
	- Added commands for reading and writing files using the `suda://` protocol.

- **Documentation**
	- Updated documentation for the *suda* plugin to reflect the new naming convention and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->