### PR TITLE
Remove `nobackup` option

### DIFF
--- a/autoload/suda.vim
+++ b/autoload/suda.vim
@@ -186,7 +186,7 @@ function! suda#BufReadCmd() abort
           \})
     silent 0delete _
     setlocal buftype=acwrite
-    setlocal nobackup noswapfile noundofile
+    setlocal noswapfile noundofile
     setlocal nomodified
     filetype detect
     redraw | echo echo_message


### PR DESCRIPTION
Close #85

The `backup` (and `nobackup`) option is global and not local to the buffer so this change affects all buffers. This is not the intended.

Note that it seems the `backup` option does not have any effect while suda write the file through `BufWriteCmd`. So this simple change should not affect the security of the plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed backup file creation during buffer reads to streamline buffer management.
  
- **Documentation**
	- Updated comments for clarity and added TODOs for potential future improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->